### PR TITLE
support latest mac os x x64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, macos-13, ubuntu-latest]
+        os: [windows-latest, macos-latest, macos-15-large, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
macos-13 build doesn't run on mac os x 15, according to github docs this is the fix https://github.com/actions/runner-images